### PR TITLE
improve origin cache implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,12 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{routing::post, Router};
 use hyper::HeaderMap;
+use queue::RetryQueue;
 use serde::Deserialize;
 use sqlx::sqlite::SqlitePool;
 use tracing::Level;
 
+use crate::cache::OriginCache;
 use crate::db::{ensure_schema, insert_request, mark_complete, mark_error};
 use crate::error::AppError;
 use crate::ingest::HttpRequest;
@@ -40,26 +42,31 @@ impl Default for Config {
     }
 }
 
-pub async fn app(config: Config) -> Result<(Router, Router, SqlitePool)> {
+pub async fn app(config: Config) -> Result<(Router, Router, RetryQueue)> {
     let pool = SqlitePool::connect(&config.database_url).await?;
-    let pool2 = pool.clone();
     ensure_schema(&pool).await?;
 
-    let mgmt_router = mgmt::router(pool.clone());
+    let origin_cache = OriginCache::new();
+
+    let mgmt_router = mgmt::router(pool.clone(), origin_cache.clone());
 
     let client = Client::new();
     let router = Router::new()
         .route("/", post(handler))
         .route("/*path", post(handler))
-        .layer(Extension(pool))
+        .layer(Extension(pool.clone()))
+        .layer(Extension(origin_cache.clone()))
         .with_state(client);
 
-    Ok((router, mgmt_router, pool2))
+    let retry_queue = RetryQueue::new(pool, origin_cache);
+
+    Ok((router, mgmt_router, retry_queue))
 }
 
 async fn handler(
     State(client): State<Client>,
     Extension(pool): Extension<SqlitePool>,
+    Extension(origin_cache): Extension<OriginCache>,
     req: Request<Body>,
 ) -> StdResult<impl IntoResponse, AppError> {
     let span = tracing::span!(Level::TRACE, "ingest");
@@ -82,7 +89,7 @@ async fn handler(
     let queued_req = insert_request(&pool, r).await?;
     let req_id = queued_req.id;
 
-    let is_success = proxy(&pool, &client, queued_req).await?;
+    let is_success = proxy(&pool, &origin_cache, &client, queued_req).await?;
 
     if is_success {
         mark_complete(&pool, req_id).await?;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,25 +1,52 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use sqlx::sqlite::SqlitePool;
+use tokio::time;
+
+use crate::cache::OriginCache;
 
 use crate::{
     db::{list_failed_requests, mark_complete, mark_error, QueuedRequest},
     proxy::{self, Client},
 };
 
-pub async fn tick(pool: SqlitePool) {
-    if let Err(err) = do_tick(pool).await {
-        // TODO flow through the request id
-        tracing::error!("tick error {:?}", err);
+pub struct RetryQueue {
+    pool: SqlitePool,
+    origin_cache: OriginCache,
+}
+
+impl RetryQueue {
+    pub fn new(pool: SqlitePool, origin_cache: OriginCache) -> Self {
+        Self { pool, origin_cache }
+    }
+
+    pub async fn start(&self) {
+        let mut interval = time::interval(Duration::from_secs(60));
+
+        loop {
+            interval.tick().await;
+            tracing::trace!("retrying failed requests");
+            self.tick().await;
+        }
+    }
+
+    pub async fn tick(&self) {
+        if let Err(err) = do_tick(&self.pool, &self.origin_cache).await {
+            // TODO flow through the request id
+            tracing::error!("tick error {:?}", err);
+        }
     }
 }
 
-async fn do_tick(pool: SqlitePool) -> Result<()> {
-    let requests = list_failed_requests(&pool).await?;
+async fn do_tick(pool: &SqlitePool, origin_cache: &OriginCache) -> Result<()> {
+    let requests = list_failed_requests(pool).await?;
 
     let mut tasks = Vec::with_capacity(requests.len());
     for request in requests {
         let pool2 = pool.clone();
-        tasks.push(tokio::spawn(retry_request(pool2, request)));
+        let origin_cache2 = origin_cache.clone();
+        tasks.push(tokio::spawn(retry_request(pool2, origin_cache2, request)));
     }
 
     for task in tasks {
@@ -32,12 +59,16 @@ async fn do_tick(pool: SqlitePool) -> Result<()> {
     Ok(())
 }
 
-async fn retry_request(pool: SqlitePool, request: QueuedRequest) -> Result<()> {
+async fn retry_request(
+    pool: SqlitePool,
+    origin_cache: OriginCache,
+    request: QueuedRequest,
+) -> Result<()> {
     tracing::trace!("retrying {:?}", &request);
 
     let req_id = request.id;
     let client = Client::new();
-    let is_success = proxy::proxy(&pool, &client, request).await?;
+    let is_success = proxy::proxy(&pool, &origin_cache, &client, request).await?;
 
     if is_success {
         mark_complete(&pool, req_id).await?;

--- a/tests/queue.rs
+++ b/tests/queue.rs
@@ -36,7 +36,7 @@ async fn queue_retry_request() {
             .unwrap();
     });
 
-    let (ingest, mgmt, pool) = app(common::config()).await.unwrap();
+    let (ingest, mgmt, retry_queue) = app(common::config()).await.unwrap();
 
     // create an origin mapping
     let domain = "example.wh.soldr.dev";
@@ -120,7 +120,7 @@ async fn queue_retry_request() {
     assert_eq!(attempts[0].response_status, 500);
     assert_eq!(attempts[0].response_body, b"unexpected error");
 
-    soldr::queue::tick(pool).await;
+    retry_queue.tick().await;
 
     // use management API to verify an attempt was made
     let response = mgmt


### PR DESCRIPTION
- hide away Arc details
- use dependency injection
- create a retry queue implementation instead of returning pool directly to main